### PR TITLE
Upgrade SwiftLint if already installed

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -12,8 +12,6 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Install Swiftlint
-        run: brew install swiftlint
 
       - name: Run Swiftlint
         run: swiftlint --config Emitron/.swiftlint.yml


### PR DESCRIPTION
It looks like SwiftLint is already installed on the `macos-latest` image now.  As a result, `brew install SwiftLint` was failing with the following messages:

```
Error: The `brew link` step did not complete successfully
...
Error: Process completed with exit code 1.
```

This commit changes the logic to install SwiftLint if and only if it
hasn't already been installed.  Otherwise, we fall back to upgrading, to
ensure that we're always using the latest version.